### PR TITLE
Change expected mint check to use current block height

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2868,7 +2868,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     if (pindex->nHeight > 0) {
         //PoW phase redistributed fees to miner. PoS stage destroys fees.
-        CAmount nExpectedMint = GetBlockValue(pindex->pprev->nHeight);
+        CAmount nExpectedMint = GetBlockValue(pindex->pprev->nHeight + 1);
         if (block.IsProofOfWork()) {
             nExpectedMint += nFees;
             LogPrint("debug", "ExpectedMint : %s", FormatMoney(pindex->nMint));


### PR DESCRIPTION
The current check on how big of a block reward should be allowed is based on the block reward value from the previous block. This causes two side effects:

1. Any increase in the block reward schedule would not be accepted in the first block of the increase, because the submitted block's reward would be too high.
2. The first block of a new lower block reward range would still accept a block submitted with a higher block reward.

Note: Since this is changing consensus critical code, it would be considered a hard fork. However, the fork would only come into play on blocks where the block reward changes and only if a block is submitted that would be rejected otherwise by either upgraded or non-upgraded nodes, but accepted by the other. If block rewards are decreasing, this change would make upgraded nodes stricter for that first block after each decrease, which means for block reward decreases, barring a modified client trying to take advantage of this quirk, the next block should be accepted by both upgraded and non-upgraded nodes.

If the vast majority of the network is upgraded before the next block reward change, then it should not really matter if this is a hard fork or not, with the possible exception of a resync if a block in the past would violate this. A resync should be tasted before applying this change.