### PR TITLE
Restart staking after exception

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1568,6 +1568,7 @@ void static ThreadStakeMinter()
         boost::this_thread::interruption_point();
     } catch (std::exception& e) {
         LogPrintf("ThreadStakeMinter() exception \n");
+            ThreadStakeMinter();
     } catch (...) {
         LogPrintf("ThreadStakeMinter() error \n");
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1568,7 +1568,7 @@ void static ThreadStakeMinter()
         boost::this_thread::interruption_point();
     } catch (std::exception& e) {
         LogPrintf("ThreadStakeMinter() exception \n");
-            ThreadStakeMinter();
+        ThreadStakeMinter();
     } catch (...) {
         LogPrintf("ThreadStakeMinter() error \n");
     }


### PR DESCRIPTION
There are a few circumstances that will cause an exception in ThreadStakeMinter(), which causes that process to exit and not restart. This change restarts ThreadStakeMinter() after one of these exceptions occur.