### PR TITLE
Remove zHLM mention from askpassphrasedialog.ui

### DIFF
--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -117,7 +117,7 @@
         <string>Serves to disable the trivial sendmoney when OS account compromised. Provides no real security.</string>
        </property>
        <property name="text">
-        <string>For anonymization, automint, and staking only</string>
+        <string>For staking only</string>
        </property>
        <property name="visible">
         <bool>false</bool>


### PR DESCRIPTION
Removes mention of automint and anonymization from the Unlock Wallet dialog box. Now says "For staking only". (trivial)